### PR TITLE
Use absolute path to git-hooks script

### DIFF
--- a/contrib/pre-push/no_master
+++ b/contrib/pre-push/no_master
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+protected_branch='(develop$)|(release_[.0-9].x$)'  
+
+function run_test {
+	# no push to master	
+	current_branch=$(git rev-parse --abbrev-ref HEAD)
+	if [[ $current_branch =~ $protected_branch ]]
+	then
+		echo "You can't push directly into $current_branch"
+		exit 1
+	else
+		exit 0
+	fi
+}
+
+case "${1}" in
+    --about )
+        echo "Prevent push into $current_branch."
+        ;;
+    * )
+        run_test
+        ;;
+esac

--- a/git-hooks
+++ b/git-hooks
@@ -149,8 +149,8 @@ function install_hooks
             echo "hooks.old already exists, perhaps you already installed?"
             return 1
         fi
-    cmd='#!/usr/bin/env bash
-git-hooks run "$0" "$@"';
+    absolute_path=`which git-hooks`
+    cmd=`printf "#!/usr/bin/env bash\n%s run \"%s\" \"%s\"" "$absolute_path" '$0' '$@'`
     install_hooks_into "${PWD}" "${cmd}"
     else
         if [ ! -d hooks.old ] ; then


### PR DESCRIPTION
Some applications like PyCharm failed to find `git-hooks` command.
A git hook before:

```
git-hooks run "$0" "$@"
```

after:

```
/usr/local/bin/git-hooks run "$0" "$@"
```
