### PR TITLE
Add a CONTRIBUTING guide for potential contributors.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+Thanks for contributing to `git-hooks`!
+
+# Writing good issues
+
+If you're filing an bug report, it would be helpful to know:
+
+* the operating system you're running (try running `uname -a`)
+* which version of bash you're running (`/usr/bin/env bash --version`),
+* which version of Git you're running (`git --version`),
+* If you're getting errors from an external program (e.g.: `find`, `grep`), which version you're using
+
+# Contributing code
+
+To set up your development environment,
+
+1. [Fork the repository](https://help.github.com/articles/fork-a-repo).
+
+	Don't forget to configure Git to sync your fork with the original `git-hooks` repository!
+2. Clone your fork
+3. Run `git hooks --install` (yes, this project has it's own git-hooks! :smile:)
+
+## Working on your feature
+
+Before making any commits, create a branch to put your changes in with `git checkout -b short_description_of_change`
+
+
+* If you add a file, make sure to put the BSD license at the top of it!
+* When you make a commit, don't forget to sign off on it (`git commit --signoff`) to signify you're okay with licensing your changes under the BSD license.
+
+## Sharing your work
+
+1. Make sure you're on the branch you want to publish: `git checkout short_description_of_change`
+2. Push your branch to your fork: `git push -t origin short_description_of_change`
+2. [Create a pull request](https://help.github.com/articles/creating-a-pull-request).


### PR DESCRIPTION
To help bugs and feature requests move faster, it's handy to answer some of the basic questions a contributor might have. Github and pengwynn/flint (a linter that checks projects for common sources of contributor friction) recommend adding a CONTRIBUTING guide. Github will even show a little message at the top of the New Issue screen if your project has one.

For more information, see [Setting guidelines for repository contributors](https://help.github.com/articles/setting-guidelines-for-repository-contributors) and [Flint](https://github.com/pengwynn/flint)

As a bit of background, when I was writing my first pull request to this project, I almost didn't notice that the repository had it's own project hooks... I just happened to test my changes inside my development environment folder and saw they had appeared in the list — I figure this might happen to other people, so I looked for a good place to put that sort of information.

This adds a simple, informal CONTRIBUTING guide with sections on writing good issues, setting up a development environment (including a reminder to `git hooks --install`) and creating pull requests... mostly I reference Github's documentation.
