### PR TITLE
Support newer versions of `find` that no longer support the "-perm +111" option.

### DIFF
--- a/git-hooks
+++ b/git-hooks
@@ -51,9 +51,9 @@ function list_hooks_in_dir
     level="${2}"
     find --help 2>&1 | grep -- '-L' 2>/dev/null >/dev/null
     if [ $? -eq 1 ] ; then
-        find "${path}/" -mindepth ${level} -maxdepth ${level} -perm +111 -type f 2>/dev/null | grep -v "^.$" | sort
+        find "${path}/" -mindepth ${level} -maxdepth ${level} -perm /111 -type f 2>/dev/null | grep -v "^.$" | sort
     else
-        find -L "${path}/" -mindepth ${level} -maxdepth ${level} -perm +111 -type f 2>/dev/null | grep -v "^.$" | sort
+        find -L "${path}/" -mindepth ${level} -maxdepth ${level} -perm /111 -type f 2>/dev/null | grep -v "^.$" | sort
     fi
 }
 

--- a/git-hooks
+++ b/git-hooks
@@ -49,12 +49,20 @@ function list_hooks_in_dir
 {
     path="${1}"
     level="${2}"
+
     find --help 2>&1 | grep -- '-L' 2>/dev/null >/dev/null
     if [ $? -eq 1 ] ; then
-        find "${path}/" -mindepth ${level} -maxdepth ${level} -perm /111 -type f 2>/dev/null | grep -v "^.$" | sort
+	Lopt=
     else
-        find -L "${path}/" -mindepth ${level} -maxdepth ${level} -perm /111 -type f 2>/dev/null | grep -v "^.$" | sort
+	Lopt=-L
     fi
+
+    find ${Lopt} "${path}/" \
+	 -mindepth ${level} \
+	 -maxdepth ${level} \
+	 \( -perm -100 -o -perm -010 -o -perm -001 \) \
+	 -type f 2>/dev/null \
+	| grep -v "^.$" | sort
 }
 
 function list_hooks


### PR DESCRIPTION
Signed-off-by: TQ Hirsch thequux@thequux.com

This patch is necessary at least for Cygwin.
