### PR TITLE
Update permission flag to find

### DIFF
--- a/git-hooks
+++ b/git-hooks
@@ -53,7 +53,7 @@ function list_hooks_in_dir
     if [ $? -eq 1 ] ; then
         find "${path}/" -mindepth ${level} -maxdepth ${level} -perm +111 -type f 2>/dev/null | grep -v "^.$" | sort
     else
-        find -L "${path}/" -mindepth ${level} -maxdepth ${level} -perm +111 -type f 2>/dev/null | grep -v "^.$" | sort
+        find -L "${path}/" -mindepth ${level} -maxdepth ${level} -perm /111 -type f 2>/dev/null | grep -v "^.$" | sort
     fi
 }
 


### PR DESCRIPTION
the -perm +111 syntax is deprecated and starting with GNU find 4.5.12 no
longer supported. /111 does the same.
