### PR TITLE
A more clearer list

### DIFF
--- a/git-hooks
+++ b/git-hooks
@@ -70,14 +70,32 @@ function list_hooks
         #echo "Git hooks are NOT installed in this repository. (Run 'git hooks --install' to install it)"
         #echo ""
     #fi
+    local dir_names=(User Repository Global)
+    local directories=$(hook_dirs)
+    local index=0
+
+    local hook_name=
+    local last_dir=
+    local current_dir=
+
+    local space_size=35
+    local about=
 
     echo 'Listing User, Project, and Global hooks:'
-    echo '---'
-    for dir in `hook_dirs`; do
-        echo "${dir}:"
+    echo ""
+
+    for dir in $directories; do
+        echo -e "\033[0;33m${dir_names[$index]}\033[0m - ${dir} "
+        index=$(($index+1))
         for hook in `list_hooks_in_dir "${dir}" 2` ; do
-            echo -n `basename \`dirname "${hook}"\``
-            echo -e "/`basename "${hook}"` \t- `${hook} --about`"
+            hook_name=$(basename "$hook")
+            current_dir=$(dirname "$hook")
+            if [ "$current_dir" != "$last_dir" ]; then
+                echo $(basename "$current_dir")
+                last_dir="$current_dir"
+            fi
+            about=$(${hook} "--about")
+            echo "  "$(printf "%-${space_size}s%s" $(echo -e "\033[1;36m${hook_name}\033[0m___" | sed -e 's/-/_/g' )  | sed -e 's/ /-/g' -e 's/_/ /g' )"- $about"
         done
         echo ""
     done

--- a/git-hooks
+++ b/git-hooks
@@ -62,14 +62,6 @@ function list_hooks
     GITDIR=`git rev-parse --git-dir`
     cat "${GITDIR}/hooks/pre-commit" 2> /dev/null | grep 'git-hooks' > /dev/null 2> /dev/null
 
-    # Comment it. This feature is not available
-    #if [ $? = 0 ] ; then
-        #echo "Git hooks ARE installed in this repository."
-        #echo ""
-    #else
-        #echo "Git hooks are NOT installed in this repository. (Run 'git hooks --install' to install it)"
-        #echo ""
-    #fi
     local dir_names=(User Repository Global)
     local directories=$(hook_dirs)
     local index=0

--- a/git-hooks
+++ b/git-hooks
@@ -61,13 +61,15 @@ function list_hooks
 {
     GITDIR=`git rev-parse --git-dir`
     cat "${GITDIR}/hooks/pre-commit" 2> /dev/null | grep 'git-hooks' > /dev/null 2> /dev/null
-    if [ $? = 0 ] ; then
-        echo "Git hooks ARE installed in this repository."
-        echo ""
-    else
-        echo "Git hooks are NOT installed in this repository. (Run 'git hooks --install' to install it)"
-        echo ""
-    fi
+
+    # Comment it. This feature is not available
+    #if [ $? = 0 ] ; then
+        #echo "Git hooks ARE installed in this repository."
+        #echo ""
+    #else
+        #echo "Git hooks are NOT installed in this repository. (Run 'git hooks --install' to install it)"
+        #echo ""
+    #fi
 
     echo 'Listing User, Project, and Global hooks:'
     echo '---'


### PR DESCRIPTION
From commit:
- No more use of tabs but equally spaces between hook and description
- Mention what part of the git-hook it is instead of showing only
  directory (user, rep, etc)
- Only mention once which subdirectory you are in (commit-msg,
  prepare…,etc)
- Colors

![screen_list](https://cloud.githubusercontent.com/assets/472515/7573032/02ccd964-f823-11e4-8a14-6b462b75ac74.png)
