### PR TITLE
The syntax `-perm +omode' was removed in favour of `-perm /omode'

### DIFF
--- a/git-hooks
+++ b/git-hooks
@@ -51,9 +51,9 @@ function list_hooks_in_dir
     level="${2}"
     find --help 2>&1 | grep -- '-L' 2>/dev/null >/dev/null
     if [ $? -eq 1 ] ; then
-        find "${path}/" -mindepth ${level} -maxdepth ${level} -perm +111 -type f 2>/dev/null | grep -v "^.$" | sort
+        find "${path}/" -mindepth ${level} -maxdepth ${level} -perm /111 -type f 2>/dev/null | grep -v "^.$" | sort
     else
-        find -L "${path}/" -mindepth ${level} -maxdepth ${level} -perm +111 -type f 2>/dev/null | grep -v "^.$" | sort
+        find -L "${path}/" -mindepth ${level} -maxdepth ${level} -perm /111 -type f 2>/dev/null | grep -v "^.$" | sort
     fi
 }
 


### PR DESCRIPTION
The interpretation of `-perm +omode' changed in findutils-4.5.11. The
syntax `-perm +omode' was removed in findutils-4.5.12, in favour of
`-perm /omode'